### PR TITLE
Feat: added partition support, allowing to partially update a database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Upcoming
 
+## 1.0.9 - 2025-03-24
+
+FEAT:
+
+ - Support for partitioning synchronization
+   using `--partition tags=(tag1|tag2)` will now only sync elements from
+   source and destination when their property named 'tags' contains either tag1 or tag2.
+   This is helpful to partially synchronize several CSV files into the same database for instance.
+   This supports regexp, so possible to use `--partition 'tags=prefix1.*'` for instance
+
 ## 1.0.8 - 2025-03-18
 
 FIX:

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ Inspired by [prom2csv](https://pypi.org/project/prom2csv/), this plugin let you 
 
 ```bash
 data2notion --help
-usage: data2notion [-h] [--version] [--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}] [--notion-log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}] [--no-progress-bar] [--notion-rate-limit NOTION_RATE_LIMIT]
-                   [--statistics {console,disabled}] [--notion-token NOTION_TOKEN]
+usage: data2notion [-h] [--version] [--log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}]
+                   [--notion-log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG}] [--no-progress-bar] [--notion-rate-limit NOTION_RATE_LIMIT]
+                   [--statistics {console,disabled}] [--notion-token NOTION_TOKEN] [--partition column_name=<regexp>]
                    {plugins,write-to-notion} ...
 
 Export some data into a notion database
@@ -170,6 +171,8 @@ options:
                         Display Statistics when program ends
   --notion-token NOTION_TOKEN
                         Notion Token to use $NOTION_TOKEN by default
+  --partition column_name=<regexp>
+                        Only synchronize records having a column matching given regexp
 
 action to perform:
   action to perform
@@ -201,4 +204,3 @@ and you might use it as any other plugin.
 ## Writing new plugins
 
 See [DESIGN.md](https://github.com/pierresouchay/data2notion/blob/main/DESIGN.md).
-


### PR DESCRIPTION
Support for partitioning synchronization using `--partition tags=(tag1|tag2)` will now only sync elements from source and destination when their property named 'tags' contains either tag1 or tag2.

This is helpful to partially synchronize several CSV files into the same database for instance.

This supports regexp, so possible to use `--partition 'tags=prefix1.*'` for instance