### PR TITLE
fix(notion-client): lock notion-client to version < 2.6 as it breaks API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Upcoming
 
+## 1.3.2 - 2025-11-08
+
+FIX:
+
+- Lock notion-client dependency to avoid API breakage
+
 ## 1.3.1 - 2025-06-16
 
 FIX:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "asynciolimiter>=1.2.0",
     "click",
-    "notion-client~=2.2",
+    "notion-client<2.6",
 ]
 
 [project.optional-dependencies]

--- a/src/data2notion_main.py
+++ b/src/data2notion_main.py
@@ -42,7 +42,7 @@ from data2notion.serialization import (
 logger = logging.getLogger("data2notion")
 
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 __plugin_api_version__ = 1.0
 


### PR DESCRIPTION
**Context**: https://github.com/ramnes/notion-sdk-py/releases/tag/2.6.0

**Solution**: lock notion-client to version < 2.6